### PR TITLE
[5.2] Fix home url in Auth Stubs

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -47,7 +47,7 @@
             <div class="collapse navbar-collapse" id="spark-navbar-collapse">
                 <!-- Left Side Of Navbar -->
                 <ul class="nav navbar-nav">
-                    <li><a href="{{ url('/') }}">Home</a></li>
+                    <li><a href="{{ url('/home') }}">Home</a></li>
                 </ul>
 
                 <!-- Right Side Of Navbar -->


### PR DESCRIPTION
`<li><a href="{{ url('/') }}">Home</a></li>` is broken.

fixed to `<li><a href="{{ url('/home') }}">Home</a></li>`
